### PR TITLE
Join when terminating threads on POSIX

### DIFF
--- a/src/Threads.h
+++ b/src/Threads.h
@@ -84,7 +84,8 @@ namespace enki
     inline bool ThreadTerminate( threadid_t threadid )
     {
         // posix equiv pthread_cancel
-        return pthread_cancel( threadid ) == 0;
+        pthread_cancel( threadid );
+        return pthread_join( threadid, NULL ) == 0;
     }
     
     inline uint32_t GetNumHardwareThreads()


### PR DESCRIPTION
There are two issues here:
1. We need to join the thread after cancelling, otherwise the id remains valid and resources won't be released.
2. The way it's currently used, we actually wait for threads to finish so pthread_cancel() doesn't do anything, returns an error and ThreadTerminate() returns false.

The return value of ThreadTerminate() is not used anywhere so things work, but we do create "zombie" threads.