### PR TITLE
CMake use target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ option( ENKITS_INSTALL              "Generate installation target" OFF )
 
 set( ENKITS_TASK_PRIORITIES_NUM "3" CACHE STRING "Number of task priorities, 1-5, 0 for defined by defaults in source" ) 
 
-include_directories( "${PROJECT_SOURCE_DIR}/src" )
-
 set( ENKITS_HEADERS
     src/LockLessMultiReadPipe.h
     src/TaskScheduler.h
@@ -45,6 +43,7 @@ else()
     add_library( enkiTS STATIC ${ENKITS_SRC} )
 endif()
 
+target_include_directories( enkiTS PUBLIC "${PROJECT_SOURCE_DIR}/src")
 
 if( ENKITS_TASK_PRIORITIES_NUM GREATER "0" )
     target_compile_definitions( enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=${ENKITS_TASK_PRIORITIES_NUM}" )    


### PR DESCRIPTION
Hi, I forked the lib to be able to include enkiTS from my own project's CMakeLists. I see you where considering doing it yourself (#74) so here's a short PR :) 

The behavior is essentially the same, this is just the newish [recommended way](https://cmake.org/cmake/help/latest/command/target_include_directories.html) to include directories and propagate them along with the CMake target. I've moved down the line so it is effective for shared and static builds.