### PR TITLE
Add NO_THREAD_NUM constant and make gtl_threadNum invalid by default.

### DIFF
--- a/src/TaskScheduler.cpp
+++ b/src/TaskScheduler.cpp
@@ -81,7 +81,7 @@ namespace enki
 
 
 // each software thread gets it's own copy of gtl_threadNum, so this is safe to use as a static variable
-static thread_local uint32_t                             gtl_threadNum       = 0;
+static thread_local uint32_t                             gtl_threadNum       = enki::NO_THREAD_NUM;
 
 namespace enki 
 {

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -76,6 +76,8 @@ namespace enki
     struct SubTaskSet;
     struct semaphoreid_t;
 
+    static constexpr uint32_t NO_THREAD_NUM = 0xFFFFFFFF;
+
     ENKITS_API uint32_t GetNumHardwareThreads();
 
     enum TaskPriority
@@ -380,9 +382,9 @@ namespace enki
 
         // Returns the current task threadNum
         // Will return 0 for thread which initialized the task scheduler,
-        // and all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
-        // and < GetNumTaskThreads() for all threads.
-        // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
+        // and NO_THREAD_NUM for all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
+        // and < GetNumTaskThreads() for all registered and internal enkiTS threads.
+        // It is guaranteed that GetThreadNum() < GetNumTaskThreads() unless it is NO_THREAD_NUM
         ENKITS_API uint32_t        GetThreadNum() const;
 
          // Call on a thread to register the thread to use the TaskScheduling API.

--- a/src/TaskScheduler_c.h
+++ b/src/TaskScheduler_c.h
@@ -53,6 +53,8 @@ typedef struct enkiCompletable      enkiCompletable;
 typedef struct enkiDependency       enkiDependency;
 typedef struct enkiCompletionAction enkiCompletionAction;
 
+static const uint32_t ENKI_NO_THREAD_NUM = 0xFFFFFFFF;
+
 typedef void (* enkiTaskExecuteRange)( uint32_t start_, uint32_t end_, uint32_t threadnum_, void* pArgs_ );
 typedef void (* enkiPinnedTaskExecute)( void* pArgs_ );
 typedef void (* enkiCompletionFunction)( void* pArgs_, uint32_t threadNum_ );
@@ -178,9 +180,9 @@ ENKITS_API uint32_t            enkiGetNumTaskThreads( enkiTaskScheduler* pETS_ )
 
 // Returns the current task threadNum
 // Will return 0 for thread which initialized the task scheduler,
-// and all other non-enkiTS threads which have not been registered ( see enkiRegisterExternalTaskThread() ),
-// and < enkiGetNumTaskThreads() for all threads.
-// It is guaranteed that enkiGetThreadNum() < enkiGetNumTaskThreads()
+// and ENKI_NO_THREAD_NUM for all other non-enkiTS threads which have not been registered ( see enkiRegisterExternalTaskThread() ),
+// and < enkiGetNumTaskThreads() for all registered and internal enkiTS threads.
+// It is guaranteed that enkiGetThreadNum() < enkiGetNumTaskThreads() unless it is ENKI_NO_THREAD_NUM
 ENKITS_API uint32_t            enkiGetThreadNum( enkiTaskScheduler* pETS_ );
 
 // Call on a thread to register the thread to use the TaskScheduling API.


### PR DESCRIPTION
Per #85, targeting `dev` branch