### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option( ENKITS_BUILD_EXAMPLES       "Build example applications" ON )
 option( ENKITS_BUILD_SHARED         "Build shared library" OFF )
 option( ENKITS_INSTALL              "Generate installation target" OFF )
 
-set( ENKITS_TASK_PRIORITIES_NUM "3" CACHE STRING "Number of task priorities, 1-5, 0 for defined by defaults in source" ) 
+set( ENKITS_TASK_PRIORITIES_NUM "3" CACHE STRING "Number of task priorities, 1-5, 0 for defined by defaults in source" )
 
 set( ENKITS_HEADERS
     src/LockLessMultiReadPipe.h
@@ -22,7 +22,7 @@ if( ENKITS_BUILD_C_INTERFACE )
     list( APPEND ENKITS_HEADERS
         src/TaskScheduler_c.h
         )
-		
+
     list( APPEND ENKITS_SRC
         src/TaskScheduler_c.cpp
         )
@@ -35,10 +35,10 @@ if( ENKITS_BUILD_SHARED )
     target_compile_definitions( enkiTS PRIVATE ENKITS_BUILD_DLL=1 )
     target_compile_definitions( enkiTS INTERFACE ENKITS_DLL=1 )
     if( UNIX )
-	    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") 
-	         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-    	endif()
-	endif ()
+        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+        endif()
+    endif ()
 else()
     add_library( enkiTS STATIC ${ENKITS_SRC} )
 endif()
@@ -46,7 +46,7 @@ endif()
 target_include_directories( enkiTS PUBLIC "${PROJECT_SOURCE_DIR}/src")
 
 if( ENKITS_TASK_PRIORITIES_NUM GREATER "0" )
-    target_compile_definitions( enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=${ENKITS_TASK_PRIORITIES_NUM}" )    
+    target_compile_definitions( enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=${ENKITS_TASK_PRIORITIES_NUM}" )
 endif()
 
 if( UNIX )
@@ -84,7 +84,7 @@ if( ENKITS_BUILD_EXAMPLES )
         add_executable( Priorities example/Priorities.cpp )
         target_link_libraries(Priorities enkiTS )
     endif()
-    
+
     add_executable( TaskThroughput example/TaskThroughput.cpp example/Timer.h )
     target_link_libraries(TaskThroughput enkiTS )
 
@@ -111,11 +111,11 @@ if( ENKITS_BUILD_EXAMPLES )
 
     add_executable( WaitForNewPinnedTasks example/WaitForNewPinnedTasks.cpp )
     target_link_libraries(WaitForNewPinnedTasks enkiTS )
-	
+
 if( ENKITS_BUILD_C_INTERFACE )
     add_executable( ParallelSum_c example/ParallelSum_c.c )
     target_link_libraries(ParallelSum_c enkiTS )
-    
+
     add_executable( PinnedTask_c example/PinnedTask_c.c )
     target_link_libraries(PinnedTask_c enkiTS )
 
@@ -135,10 +135,10 @@ if( ENKITS_BUILD_C_INTERFACE )
 
     add_executable( CompletionAction_c example/CompletionAction_c.c )
     target_link_libraries(CompletionAction_c enkiTS )
-	
-	add_executable( WaitForNewPinnedTasks_c example/WaitForNewPinnedTasks_c.c )
+
+    add_executable( WaitForNewPinnedTasks_c example/WaitForNewPinnedTasks_c.c )
     target_link_libraries(WaitForNewPinnedTasks_c enkiTS )
 
-endif()    
+endif()
 
 endif()

--- a/src/TaskScheduler.cpp
+++ b/src/TaskScheduler.cpp
@@ -73,7 +73,7 @@ namespace enki
     static const uint32_t gc_MaxStolenPartitions     = 1 << gc_PipeSizeLog2;
     static const uint32_t gc_CacheLineSize           = 64;
     // awaiting std::hardware_constructive_interference_size
-};
+}
 
 // thread_local not well supported yet by C++11 compilers.
 #ifdef _MSC_VER
@@ -86,7 +86,7 @@ namespace enki
 #endif
 
 
-// each software thread gets it's own copy of gtl_threadNum, so this is safe to use as a static variable
+// each software thread gets its own copy of gtl_threadNum, so this is safe to use as a static variable
 static thread_local uint32_t                             gtl_threadNum       = 0;
 
 namespace enki
@@ -161,7 +161,7 @@ namespace
         }
     }
     #else
-    static void SpinWait( uint32_t spinCount_ )
+    void SpinWait( uint32_t spinCount_ )
     {
         while( spinCount_ )
         {
@@ -201,7 +201,7 @@ ENKITS_API void* enki::DefaultAllocFunc( size_t align_, size_t size_, void* user
     }
 #endif
     return pRet;
-};
+}
 
 ENKITS_API void  enki::DefaultFreeFunc(  void* ptr_,   size_t size_, void* userData_, const char* file_, int line_ )
 {
@@ -211,7 +211,7 @@ ENKITS_API void  enki::DefaultFreeFunc(  void* ptr_,   size_t size_, void* userD
 #else
     free( ptr_ );
 #endif
-};
+}
 
 bool TaskScheduler::RegisterExternalTaskThread()
 {
@@ -304,8 +304,6 @@ void TaskScheduler::TaskingThreadFunction( const ThreadArgs& args_ )
     pTS->m_NumInternalTaskThreadsRunning.fetch_sub( 1, std::memory_order_release );
     pTS->m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_STOPPED, std::memory_order_release );
     SafeCallback( pTS->m_Config.profilerCallbacks.threadStop, threadNum );
-    return;
-
 }
 
 
@@ -625,7 +623,7 @@ bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_
 void TaskScheduler::TaskComplete( ICompletable* pTask_, bool bWakeThreads_, uint32_t threadNum_ )
 {
     // It must be impossible for a thread to enter the sleeping wait prior to the load of m_WaitingForTaskCount
-    // in this function, so we introduce an gc_TaskAlmostCompleteCount to prevent this.
+    // in this function, so we introduce a gc_TaskAlmostCompleteCount to prevent this.
     ENKI_ASSERT( gc_TaskAlmostCompleteCount == pTask_->m_RunningCount.load( std::memory_order_acquire ) );
     bool bCallWakeThreads = bWakeThreads_ && pTask_->m_WaitingForTaskCount.load( std::memory_order_acquire );
 
@@ -1063,7 +1061,7 @@ void TaskScheduler::WaitforAll()
                 dummyWaitTask.threadNum = ( dummyWaitTask.threadNum + 1 ) % m_NumThreads;
 
                 // We can only add a pinned task to wait on if we find an enki Task Thread which isn't this thread.
-                // Otherwise we have to busy wait.
+                // Otherwise, we have to busy wait.
                 if( dummyWaitTask.threadNum != ourThreadNum && dummyWaitTask.threadNum > m_Config.numExternalTaskThreads )
                 {
                     ThreadState state = m_pThreadDataStore[ dummyWaitTask.threadNum ].threadState.load( std::memory_order_acquire );
@@ -1116,7 +1114,7 @@ void TaskScheduler::WaitforAll()
                 case ENKI_THREAD_STATE_WAIT_NEW_TASKS:
                 case ENKI_THREAD_STATE_STOPPED:
                     break;
-                 };
+                }
             }
         }
         if( !otherThreadsRunning )
@@ -1260,7 +1258,7 @@ TaskScheduler::TaskScheduler()
         , m_NumThreads(0)
         , m_pThreadDataStore(NULL)
         , m_pThreads(NULL)
-        , m_bRunning(0)
+        , m_bRunning(false)
         , m_NumInternalTaskThreadsRunning(0)
         , m_NumThreadsWaitingForNewTasks(0)
         , m_NumThreadsWaitingForTaskCompletion(0)

--- a/src/TaskScheduler.cpp
+++ b/src/TaskScheduler.cpp
@@ -515,7 +515,7 @@ bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t& hintPipeToCheck_i
 
 static inline uint32_t RotateLeft( uint32_t value, int32_t count )
 {
-	return ( value << count ) | ( value >> ( 32 - count ));
+    return ( value << count ) | ( value >> ( 32 - count ));
 }
 /*  xxHash variant based on documentation on
     https://github.com/Cyan4973/xxHash/blob/eec5700f4d62113b47ee548edbc4746f61ffb098/doc/xxhash_spec.md
@@ -1202,12 +1202,12 @@ T* TaskScheduler::NewArray( size_t num_, const char* file_, int line_  )
     T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), num_*sizeof(T), m_Config.customAllocator.userData, file_, line_ );
     if( !std::is_trivial<T>::value )
     {
-		T* pCurr = pRet;
+        T* pCurr = pRet;
         for( size_t i = 0; i < num_; ++i )
         {
-			void* pBuffer = pCurr;
+            void* pBuffer = pCurr;
             pCurr = new(pBuffer) T;
-			++pCurr;
+            ++pCurr;
         }
     }
     return pRet;

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -1,13 +1,13 @@
 // Copyright (c) 2013 Doug Binks
-// 
+//
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
 // arising from the use of this software.
-// 
+//
 // Permission is granted to anyone to use this software for any purpose,
 // including commercial applications, and to alter it and redistribute it
 // freely, subject to the following restrictions:
-// 
+//
 // 1. The origin of this software must not be misrepresented; you must not
 //    claim that you wrote the original software. If you use this software
 //    in a product, an acknowledgement in the product documentation would be
@@ -60,7 +60,6 @@
 
 namespace enki
 {
-
     struct TaskSetPartition
     {
         uint32_t start;
@@ -89,7 +88,7 @@ namespace enki
 #endif
 #if ( ENKITS_TASK_PRIORITIES_NUM > 4 )
         TASK_PRIORITY_MED_LO,
-#endif 
+#endif
 #if ( ENKITS_TASK_PRIORITIES_NUM > 1 )
         TASK_PRIORITY_LOW,
 #endif
@@ -154,7 +153,7 @@ namespace enki
         // range_ where range.start >= 0; range.start < range.end; and range.end < m_SetSize;
         // The range values should be mapped so that linearly processing them in order is cache friendly
         // i.e. neighbouring values should be close together.
-        // threadnum should not be used for changing processing of data, it's intended purpose
+        // threadnum_ should not be used for changing processing of data, it's intended purpose
         // is to allow per-thread data buckets for output.
         virtual void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  ) = 0;
 
@@ -163,7 +162,7 @@ namespace enki
 
         // Min Range - Minimum size of of TaskSetPartition range when splitting a task set into partitions.
         // Designed for reducing scheduling overhead by preventing set being
-        // divided up too small. Ranges passed to ExecuteRange will *not* be a mulitple of this,
+        // divided up too small. Ranges passed to ExecuteRange will *not* be a multiple of this,
         // only attempts to deliver range sizes larger than this most of the time.
         // This should be set to a value which results in computation effort of at least 10k
         // clock cycles to minimize task scheduler overhead.
@@ -186,7 +185,7 @@ namespace enki
         IPinnedTask( uint32_t threadNum_ ) : threadNum(threadNum_) {}  // default is to run a task on main thread
 
         // IPinnedTask needs to be non abstract for intrusive list functionality.
-        // Should never be called as should be overridden.
+        // Should never be called as is, should be overridden.
         virtual void Execute() { ENKI_ASSERT(false); }
 
         uint32_t                  threadNum = 0; // thread to run this pinned task on
@@ -195,7 +194,7 @@ namespace enki
         void         OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ ) override final;
     };
 
-    // TaskSet - a utility task set for creating tasks based on std::func.
+    // TaskSet - a utility task set for creating tasks based on std::function.
     typedef std::function<void (TaskSetPartition range, uint32_t threadnum  )> TaskSetFunction;
     class TaskSet : public ITaskSet
     {
@@ -224,9 +223,9 @@ namespace enki
     class Dependency
     {
     public:
-                        Dependency() = default; 
+                        Dependency() = default;
                         Dependency( const Dependency& ) = delete;
-        ENKITS_API      Dependency( Dependency&& ) noexcept;	
+        ENKITS_API      Dependency( Dependency&& ) noexcept;
         ENKITS_API      Dependency(    const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ );
         ENKITS_API      ~Dependency();
 
@@ -278,7 +277,7 @@ namespace enki
         // See TaskScheduler::RegisterExternalTaskThread() for usage.
         // Defaults to 0. The thread used to initialize the TaskScheduler can also use the TaskScheduler API.
         // Thus there are (numTaskThreadsToCreate + numExternalTaskThreads + 1) able to use the API, with this
-        // defaulting to the number of harware threads available to the system.
+        // defaulting to the number of hardware threads available to the system.
         uint32_t          numExternalTaskThreads = 0;
 
         ProfilerCallbacks profilerCallbacks = {};
@@ -315,7 +314,7 @@ namespace enki
         // while( !GetIsShutdownRequested() ) {} can be used in tasks which loop, to check if enkiTS has been requested to shutdown.
         // If GetIsShutdownRequested() returns true should then exit. Not required for finite tasks
         // Safe to use with WaitforAllAndShutdown() and ShutdownNow() where this will be set
-        // Not safe to use with WaitforAll(). 
+        // Not safe to use with WaitforAll().
         inline     bool            GetIsShutdownRequested() const { return m_bShutdownRequested.load( std::memory_order_acquire ); }
 
         // while( !GetIsWaitforAllCalled() ) {} can be used in tasks which loop, to check if WaitforAll() has been called.
@@ -338,18 +337,18 @@ namespace enki
         ENKITS_API void            RunPinnedTasks();
 
         // Runs the TaskSets in pipe until true == pTaskSet->GetIsComplete();
-        // should only be called from thread which created the taskscheduler , or within a task
-        // if called with 0 it will try to run tasks, and return if none available.
+        // Should only be called from thread which created the task scheduler, or within a task.
+        // If called with 0 it will try to run tasks, and return if none available.
         // To run only a subset of tasks, set priorityOfLowestToRun_ to a high priority.
         // Default is lowest priority available.
         // Only wait for child tasks of the current task otherwise a deadlock could occur.
-        // WaitforTask will exit if ShutdownNow() is called even if pCompletable_ is not complete
+        // WaitforTask will exit if ShutdownNow() is called even if pCompletable_ is not complete.
         ENKITS_API void            WaitforTask( const ICompletable* pCompletable_, enki::TaskPriority priorityOfLowestToRun_ = TaskPriority(TASK_PRIORITY_NUM - 1) );
 
         // Waits for all task sets to complete - not guaranteed to work unless we know we
         // are in a situation where tasks aren't being continuously added.
         // If you are running tasks which loop, make sure to check GetIsWaitforAllCalled() and exit
-        // WaitfoAll will exit if ShutdownNow() is called even if there are still tasks to run or currently running
+        // WaitforAll will exit if ShutdownNow() is called even if there are still tasks to run or currently running
         ENKITS_API void            WaitforAll();
 
         // Waits for all task sets to complete and shutdown threads - not guaranteed to work unless we know we
@@ -365,8 +364,8 @@ namespace enki
         // to be in an undefined state in which should not be re-launched.
         ENKITS_API void            ShutdownNow();
 
-        // Waits for the current thread to receive a PinnedTask
-        // Will not run any tasks - use with RunPinnedTasks()
+        // Waits for the current thread to receive a PinnedTask.
+        // Will not run any tasks - use with RunPinnedTasks().
         // Can be used with both ExternalTaskThreads or with an enkiTS tasking thread to create
         // a thread which only runs pinned tasks. If enkiTS threads are used can create
         // extra enkiTS task threads to handle non blocking computation via normal tasks.
@@ -378,24 +377,24 @@ namespace enki
         // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
         ENKITS_API uint32_t        GetNumTaskThreads() const;
 
-        // Returns the current task threadNum
+        // Returns the current task threadNum.
         // Will return 0 for thread which initialized the task scheduler,
         // and all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
         // and < GetNumTaskThreads() for all threads.
         // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
         ENKITS_API uint32_t        GetThreadNum() const;
 
-         // Call on a thread to register the thread to use the TaskScheduling API.
+        // Call on a thread to register the thread to use the TaskScheduling API.
         // This is implicitly done for the thread which initializes the TaskScheduler
         // Intended for developers who have threads who need to call the TaskScheduler API
-        // Returns true if successfull, false if not.
+        // Returns true if successful, false if not.
         // Can only have numExternalTaskThreads registered at any one time, which must be set
         // at initialization time.
         ENKITS_API bool            RegisterExternalTaskThread();
 
         // As RegisterExternalTaskThread() but explicitly requests a given thread number.
         // threadNumToRegister_ must be  >= GetNumFirstExternalTaskThread()
-        // and < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads )
+        // and < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads ).
         ENKITS_API bool            RegisterExternalTaskThread( uint32_t threadNumToRegister_ );
 
         // Call on a thread on which RegisterExternalTaskThread has been called to deregister that thread.
@@ -416,13 +415,13 @@ namespace enki
         // ------------- Start DEPRECATED Functions -------------
         // DEPRECATED: use GetIsShutdownRequested() instead of GetIsRunning() in external code
         // while( GetIsRunning() ) {} can be used in tasks which loop, to check if enkiTS has been shutdown.
-        // If GetIsRunning() returns false should then exit. Not required for finite tasks
+        // If GetIsRunning() returns false should then exit. Not required for finite tasks.
         inline     bool            GetIsRunning() const { return m_bRunning.load( std::memory_order_acquire ); }
 
-        // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask
+        // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask.
         inline void                WaitforTaskSet( const ICompletable* pCompletable_ ) { WaitforTask( pCompletable_ ); }
 
-        // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead
+        // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead.
         // Returns the ProfilerCallbacks structure so that it can be modified to
         // set the callbacks. Should be set prior to initialization.
         inline ProfilerCallbacks* GetProfilerCallbacks() { return &m_Config.profilerCallbacks; }

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -30,7 +30,7 @@
     #define ENKITS_TASK_PRIORITIES_NUM 3
 #endif
 
-#ifndef	ENKITS_API
+#ifndef ENKITS_API
 #if   defined(_WIN32) && defined(ENKITS_BUILD_DLL)
     // Building enkiTS as a DLL
     #define ENKITS_API __declspec(dllexport)

--- a/src/TaskScheduler_c.cpp
+++ b/src/TaskScheduler_c.cpp
@@ -1,13 +1,13 @@
 // Copyright (c) 2013 Doug Binks
-// 
+//
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
 // arising from the use of this software.
-// 
+//
 // Permission is granted to anyone to use this software for any purpose,
 // including commercial applications, and to alter it and redistribute it
 // freely, subject to the following restrictions:
-// 
+//
 // 1. The origin of this software must not be misrepresented; you must not
 //    claim that you wrote the original software. If you use this software
 //    in a product, an acknowledgement in the product documentation would be
@@ -139,13 +139,13 @@ struct enkiTaskSchedulerConfig enkiGetTaskSchedulerConfig( enkiTaskScheduler* pE
     enkiTaskSchedulerConfig configC;
     configC.numExternalTaskThreads                             = config.numExternalTaskThreads;
     configC.numTaskThreadsToCreate                             = config.numTaskThreadsToCreate;
-    configC.profilerCallbacks.threadStart                      = config.profilerCallbacks.threadStart;                      
-    configC.profilerCallbacks.threadStop                       = config.profilerCallbacks.threadStop;                       
-    configC.profilerCallbacks.waitForNewTaskSuspendStart       = config.profilerCallbacks.waitForNewTaskSuspendStart;      
-    configC.profilerCallbacks.waitForNewTaskSuspendStop        = config.profilerCallbacks.waitForNewTaskSuspendStop;        
-    configC.profilerCallbacks.waitForTaskCompleteStart         = config.profilerCallbacks.waitForTaskCompleteStart;         
-    configC.profilerCallbacks.waitForTaskCompleteStop          = config.profilerCallbacks.waitForTaskCompleteStop;          
-    configC.profilerCallbacks.waitForTaskCompleteSuspendStart  = config.profilerCallbacks.waitForTaskCompleteSuspendStart;  
+    configC.profilerCallbacks.threadStart                      = config.profilerCallbacks.threadStart;
+    configC.profilerCallbacks.threadStop                       = config.profilerCallbacks.threadStop;
+    configC.profilerCallbacks.waitForNewTaskSuspendStart       = config.profilerCallbacks.waitForNewTaskSuspendStart;
+    configC.profilerCallbacks.waitForNewTaskSuspendStop        = config.profilerCallbacks.waitForNewTaskSuspendStop;
+    configC.profilerCallbacks.waitForTaskCompleteStart         = config.profilerCallbacks.waitForTaskCompleteStart;
+    configC.profilerCallbacks.waitForTaskCompleteStop          = config.profilerCallbacks.waitForTaskCompleteStop;
+    configC.profilerCallbacks.waitForTaskCompleteSuspendStart  = config.profilerCallbacks.waitForTaskCompleteSuspendStart;
     configC.profilerCallbacks.waitForTaskCompleteSuspendStop   = config.profilerCallbacks.waitForTaskCompleteSuspendStop;
     configC.customAllocator.alloc                              = config.customAllocator.alloc;
     configC.customAllocator.free                               = config.customAllocator.free;
@@ -173,14 +173,14 @@ void enkiInitTaskSchedulerWithConfig( enkiTaskScheduler* pETS_, struct enkiTaskS
     TaskSchedulerConfig config;
     config.numExternalTaskThreads                             = config_.numExternalTaskThreads;
     config.numTaskThreadsToCreate                             = config_.numTaskThreadsToCreate;
-    config.profilerCallbacks.threadStart                      = config_.profilerCallbacks.threadStart;                      
-    config.profilerCallbacks.threadStop                       = config_.profilerCallbacks.threadStop;                       
-    config.profilerCallbacks.waitForNewTaskSuspendStart       = config_.profilerCallbacks.waitForNewTaskSuspendStart;      
-    config.profilerCallbacks.waitForNewTaskSuspendStop        = config_.profilerCallbacks.waitForNewTaskSuspendStop;        
-    config.profilerCallbacks.waitForTaskCompleteStart         = config_.profilerCallbacks.waitForTaskCompleteStart;         
-    config.profilerCallbacks.waitForTaskCompleteStop          = config_.profilerCallbacks.waitForTaskCompleteStop;          
-    config.profilerCallbacks.waitForTaskCompleteSuspendStart  = config_.profilerCallbacks.waitForTaskCompleteSuspendStart;  
-    config.profilerCallbacks.waitForTaskCompleteSuspendStop   = config_.profilerCallbacks.waitForTaskCompleteSuspendStop;   
+    config.profilerCallbacks.threadStart                      = config_.profilerCallbacks.threadStart;
+    config.profilerCallbacks.threadStop                       = config_.profilerCallbacks.threadStop;
+    config.profilerCallbacks.waitForNewTaskSuspendStart       = config_.profilerCallbacks.waitForNewTaskSuspendStart;
+    config.profilerCallbacks.waitForNewTaskSuspendStop        = config_.profilerCallbacks.waitForNewTaskSuspendStop;
+    config.profilerCallbacks.waitForTaskCompleteStart         = config_.profilerCallbacks.waitForTaskCompleteStart;
+    config.profilerCallbacks.waitForTaskCompleteStop          = config_.profilerCallbacks.waitForTaskCompleteStop;
+    config.profilerCallbacks.waitForTaskCompleteSuspendStart  = config_.profilerCallbacks.waitForTaskCompleteSuspendStart;
+    config.profilerCallbacks.waitForTaskCompleteSuspendStop   = config_.profilerCallbacks.waitForTaskCompleteSuspendStop;
     config.customAllocator.alloc                              = config_.customAllocator.alloc;
     config.customAllocator.free                               = config_.customAllocator.free;
     config.customAllocator.userData                         = config_.customAllocator.userData;

--- a/src/TaskScheduler_c.h
+++ b/src/TaskScheduler_c.h
@@ -1,13 +1,13 @@
 // Copyright (c) 2013 Doug Binks
-// 
+//
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
 // arising from the use of this software.
-// 
+//
 // Permission is granted to anyone to use this software for any purpose,
 // including commercial applications, and to alter it and redistribute it
 // freely, subject to the following restrictions:
-// 
+//
 // 1. The origin of this software must not be misrepresented; you must not
 //    claim that you wrote the original software. If you use this software
 //    in a product, an acknowledgement in the product documentation would be
@@ -117,7 +117,7 @@ struct enkiTaskSchedulerConfig
     // See TaskScheduler::RegisterExternalTaskThread() for usage.
     // Defaults to 0. The thread used to initialize the TaskScheduler can also use the TaskScheduler API.
     // Thus there are (numTaskThreadsToCreate + numExternalTaskThreads + 1) able to use the API, with this
-    // defaulting to the number of harware threads available to the system.
+    // defaulting to the number of hardware threads available to the system.
     uint32_t              numExternalTaskThreads;
 
     struct enkiProfilerCallbacks profilerCallbacks;
@@ -163,11 +163,11 @@ ENKITS_API void                enkiInitTaskSchedulerWithConfig( enkiTaskSchedule
 // This function can be safely called even if enkiInit* has not been called.
 ENKITS_API void                enkiWaitforAllAndShutdown( enkiTaskScheduler* pETS_ );
 
-// Delete a task scheduler
+// Delete a task scheduler.
 ENKITS_API void                enkiDeleteTaskScheduler( enkiTaskScheduler* pETS_ );
 
 // Waits for all task sets to complete - not guaranteed to work unless we know we
-// are in a situation where tasks aren't being continuosly added.
+// are in a situation where tasks aren't being continuously added.
 ENKITS_API void                enkiWaitForAll( enkiTaskScheduler* pETS_ );
 
 // Returns the number of threads created for running tasks + number of external threads
@@ -176,7 +176,7 @@ ENKITS_API void                enkiWaitForAll( enkiTaskScheduler* pETS_ );
 // It is guaranteed that enkiGetThreadNum() < enkiGetNumTaskThreads()
 ENKITS_API uint32_t            enkiGetNumTaskThreads( enkiTaskScheduler* pETS_ );
 
-// Returns the current task threadNum
+// Returns the current task threadNum.
 // Will return 0 for thread which initialized the task scheduler,
 // and all other non-enkiTS threads which have not been registered ( see enkiRegisterExternalTaskThread() ),
 // and < enkiGetNumTaskThreads() for all threads.
@@ -186,7 +186,7 @@ ENKITS_API uint32_t            enkiGetThreadNum( enkiTaskScheduler* pETS_ );
 // Call on a thread to register the thread to use the TaskScheduling API.
 // This is implicitly done for the thread which initializes the TaskScheduler
 // Intended for developers who have threads who need to call the TaskScheduler API
-// Returns true if successfull, false if not.
+// Returns true if successful, false if not.
 // Can only have numExternalTaskThreads registered at any one time, which must be set
 // at initialization time.
 ENKITS_API int                 enkiRegisterExternalTaskThread( enkiTaskScheduler* pETS_ );
@@ -248,7 +248,7 @@ ENKITS_API void                enkiAddTaskSetArgs( enkiTaskScheduler* pETS_, enk
 
 // Schedule the task with a minimum range.
 // This should be set to a value which results in computation effort of at least 10k
-// clock cycles to minimize tast scheduler overhead.
+// clock cycles to minimize task scheduler overhead.
 // NOTE: The last partition will be smaller than m_MinRange if m_SetSize is not a multiple
 // of m_MinRange.
 // Also known as grain size in literature.
@@ -258,7 +258,7 @@ ENKITS_API void                enkiAddTaskSetMinRange( enkiTaskScheduler* pETS_,
 ENKITS_API int                 enkiIsTaskSetComplete( enkiTaskScheduler* pETS_, enkiTaskSet* pTaskSet_ );
 
 // Wait for a given task.
-// should only be called from thread which created the taskscheduler , or within a task
+// should only be called from thread which created the task scheduler, or within a task
 // if called with 0 it will try to run tasks, and return if none available.
 // Only wait for child tasks of the current task otherwise a deadlock could occur.
 ENKITS_API void                enkiWaitForTaskSet( enkiTaskScheduler* pETS_, enkiTaskSet* pTaskSet_ );
@@ -305,7 +305,7 @@ ENKITS_API void                enkiRunPinnedTasks( enkiTaskScheduler * pETS_ );
 ENKITS_API int                 enkiIsPinnedTaskComplete( enkiTaskScheduler* pETS_, enkiPinnedTask* pTask_ );
 
 // Wait for a given pinned task.
-// should only be called from thread which created the taskscheduler, or within a task
+// should only be called from thread which created the task scheduler, or within a task
 // if called with 0 it will try to run tasks, and return if none available.
 // Only wait for child tasks of the current task otherwise a deadlock could occur.
 ENKITS_API void                enkiWaitForPinnedTask( enkiTaskScheduler* pETS_, enkiPinnedTask* pTask_ );
@@ -322,7 +322,7 @@ ENKITS_API void                enkiWaitForPinnedTaskPriority( enkiTaskScheduler*
 ENKITS_API void                enkiWaitForNewPinnedTasks( enkiTaskScheduler* pETS_ );
 
 
-/* ----------------------------   Completables  ---------------------------- */
+/* ----------------------------  Completables  ---------------------------- */
 // Get a pointer to an enkiCompletable from an enkiTaskSet.
 // Do not call enkiDeleteCompletable on the returned pointer.
 ENKITS_API enkiCompletable*    enkiGetCompletableFromTaskSet(    enkiTaskSet* pTaskSet_ );
@@ -344,7 +344,7 @@ ENKITS_API enkiCompletable*    enkiCreateCompletable( enkiTaskScheduler* pETS_ )
 ENKITS_API void                enkiDeleteCompletable( enkiTaskScheduler* pETS_, enkiCompletable* pCompletable_ );
 
 // Wait for a given completable.
-// should only be called from thread which created the taskscheduler, or within a task
+// should only be called from thread which created the task scheduler, or within a task
 // if called with 0 it will try to run tasks, and return if none available.
 // Only wait for child tasks of the current task otherwise a deadlock could occur.
 ENKITS_API void                enkiWaitForCompletable( enkiTaskScheduler* pETS_, enkiCompletable* pTask_ );
@@ -356,14 +356,14 @@ ENKITS_API void                enkiWaitForCompletablePriority( enkiTaskScheduler
 
 /* ----------------------------   Dependencies  ---------------------------- */
 // Create an enkiDependency, used to set dependencies between tasks
-// Call enkiDeleteDependency to delete
+// Call enkiDeleteDependency to delete.
 ENKITS_API enkiDependency*     enkiCreateDependency( enkiTaskScheduler* pETS_ );
 
-// Delerte an enkiDependency creatged with enkiCreateDependency
+// Delete an enkiDependency created with enkiCreateDependency.
 ENKITS_API void                enkiDeleteDependency( enkiTaskScheduler* pETS_, enkiDependency* pDependency_ );
 
 // Set a dependency between pDependencyTask_ and pTaskToRunOnCompletion_
-// Such that when all depedencies of pTaskToRunOnCompletion_ are completed it will run
+// such that when all dependencies of pTaskToRunOnCompletion_ are completed it will run.
 ENKITS_API void                enkiSetDependency(
                                     enkiDependency*  pDependency_,
                                     enkiCompletable* pDependencyTask_,

--- a/src/TaskScheduler_c.h
+++ b/src/TaskScheduler_c.h
@@ -298,7 +298,7 @@ ENKITS_API void                enkiAddPinnedTaskArgs( enkiTaskScheduler* pETS_, 
                                            void* pArgs_ );
 
 // This function will run any enkiPinnedTask* for current thread, but not run other
-// Main thread should call this or use a wait to ensure it's tasks are run.
+// Main thread should call this or use a wait to ensure its tasks are run.
 ENKITS_API void                enkiRunPinnedTasks( enkiTaskScheduler * pETS_ );
 
 // Check if enkiPinnedTask is complete. Doesn't wait. Returns 1 if complete, 0 if not.


### PR DESCRIPTION
This is a simple PR with some minor fixes I spotted while reading through the source code.

- Minor typo fixes
- Minor grammatical fixes
- Removal of trailing whitespace
- Removal of tab characters
- Removal of redundant semicolons (e.g. `;` at end of a namespace)
- `std::move` of constructor parameter passed by value (to avoid additional copies)
- use of `false` literal instead of `0`
- Removal of redundant `override` keyword when used with `final`
- use `cassert` and `cstdint` C++ headers as opposed to `assert.h` and `stdint.h` C headers in `TaskScheduler.h`

(_The change does not include switching .cpp files to use_ `nullptr` _instead of_ `NULL`, _but I would happily do that_ 🙂 _It also looks like_ `RotateLeft` _is unused and could be removed_).

I also am not sure what the comment...

```
// check if have tasks inside threadState change but before waiting
```

on line `1164` of `TaskScheduler.cpp` means exactly, if this could be rephrased in a separate change that would be great!

I won't be offended at all if you aren't interested in the changes (they're pretty much all superficial) or if you'd rather implement them yourself and not merge this PR that's also fine. I just thought I might as well share it in case it was useful as I was noodling around with this in my fork.

Thanks!