### PR TITLE
Add support for CMake find_package Config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project( enkiTS )
 
+include(GNUInstallDirs)
+
 option( ENKITS_BUILD_C_INTERFACE    "Build C interface" ON )
 option( ENKITS_BUILD_EXAMPLES       "Build example applications" ON )
 option( ENKITS_BUILD_SHARED         "Build shared library" OFF )
@@ -43,7 +45,9 @@ else()
     add_library( enkiTS STATIC ${ENKITS_SRC} )
 endif()
 
-target_include_directories( enkiTS PUBLIC "${PROJECT_SOURCE_DIR}/src")
+target_include_directories( enkiTS PUBLIC
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 if( ENKITS_TASK_PRIORITIES_NUM GREATER "0" )
     target_compile_definitions( enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=${ENKITS_TASK_PRIORITIES_NUM}" )
@@ -59,8 +63,15 @@ if( UNIX )
 endif()
 
 if( ENKITS_INSTALL )
-    install(TARGETS enkiTS DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/enkiTS")
-    install(FILES ${ENKITS_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/enkiTS")
+    install(
+        TARGETS enkiTS
+        EXPORT enkiTS-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(
+        EXPORT enkiTS-config
+        NAMESPACE enkiTS::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/enkiTS)
 endif()
 
 if( UNIX )


### PR DESCRIPTION
This change allows enkiTS to be installed and then used with `find_package(enkiTS)` (or more precisely `find_package(enkiTS REQUIRED CONFIG)`.

An example usage is using CMake `AddExternal_Project` such as...

```
ExternalProject_Add(
  enkiTS
  GIT_REPOSITORY https://github.com/pr0g/enkiTS.git
  GIT_TAG cd8e8c2af2e7c3f7d7719ccbed25f147d63b71f6
  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/enkiTS/build/${build_type_dir}
  INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
  CMAKE_ARGS ${build_type_arg} -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             "$<$<CONFIG:Debug>:-DCMAKE_DEBUG_POSTFIX=d>"
             -DENKITS_BUILD_EXAMPLES=OFF -DENKITS_INSTALL=ON)
```

and then consuming `enkiTS` in a downstream application library with...

```
find_package(enkiTS REQUIRED CONFIG)
...
target_link_libraries(${PROJECT_NAME} PRIVATE enkiTS::enkiTS)
```

It can then be used by using the above `find_package` command after installing locally and telling CMake where to find it with `-DCMAKE_PREFIX_PATH`.

I'm definitely not a CMake expert but I have used this pattern successfully in a number of projects and have written up a number of use cases here that might be useful to review - [cmake examples](https://github.com/pr0g/cmake-examples).

If it would be useful to include a sample project showing this in action I can include an example as well. Thanks!