### PR TITLE
Fix CMake config filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,13 +65,12 @@ endif()
 if( ENKITS_INSTALL )
     install(
         TARGETS enkiTS
-        EXPORT enkiTS-config
+        EXPORT enkiTSConfig
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(
-        EXPORT enkiTS-config
+        EXPORT enkiTSConfig
         NAMESPACE enkiTS::
-        FILE enkiTSConfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/enkiTS)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if( ENKITS_INSTALL )
     install(
         EXPORT enkiTS-config
         NAMESPACE enkiTS::
+        FILE enkiTSConfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/enkiTS)
 endif()
 


### PR DESCRIPTION
On case-sensitive filesystems, the default name `enkiTS-config.cmake`  doesn't work. This PR implements the correct case-sensitive filename.
(The case-insensitve name would be `enkits-config.cmake`.)

~~~
Could not find a package configuration file provided by "enkiTS" with any
  of the following names:

    enkiTSConfig.cmake
    enkits-config.cmake
~~~