### PR TITLE
MinGW64 `memset` fix

### DIFF
--- a/example/ParallelSum.cpp
+++ b/example/ParallelSum.cpp
@@ -22,11 +22,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <assert.h>
-#include <cstring>
-
-#ifndef _WIN32
-    #include <string.h>
-#endif
+#include <string.h>
 
 using namespace enki;
 

--- a/example/ParallelSum.cpp
+++ b/example/ParallelSum.cpp
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <assert.h>
+#include <cstring>
 
 #ifndef _WIN32
     #include <string.h>

--- a/example/TaskOverhead.cpp
+++ b/example/TaskOverhead.cpp
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #undef __STDC_FORMAT_MACROS
 #include <assert.h>
+#include <cstring>
 
 #ifndef _WIN32
     #include <string.h>

--- a/example/TaskOverhead.cpp
+++ b/example/TaskOverhead.cpp
@@ -24,11 +24,7 @@
 #include <inttypes.h>
 #undef __STDC_FORMAT_MACROS
 #include <assert.h>
-#include <cstring>
-
-#ifndef _WIN32
-    #include <string.h>
-#endif
+#include <string.h>
 
 using namespace enki;
 

--- a/example/TaskThroughput.cpp
+++ b/example/TaskThroughput.cpp
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <math.h>
+#include <cstring>
 
 #ifndef _WIN32
     #include <string.h>

--- a/example/TaskThroughput.cpp
+++ b/example/TaskThroughput.cpp
@@ -23,10 +23,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <cstring>
-
-#ifndef _WIN32
-    #include <string.h>
-#endif
+#include <string.h>
 
 using namespace enki;
 

--- a/example/TestAll.cpp
+++ b/example/TestAll.cpp
@@ -25,10 +25,7 @@
 #include <vector>
 #include <algorithm>
 #include <cstring>
-
-#ifndef _WIN32
-    #include <string.h>
-#endif
+#include <string.h>
 
 using namespace enki;
 

--- a/example/TestAll.cpp
+++ b/example/TestAll.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #ifndef _WIN32
     #include <string.h>


### PR DESCRIPTION
When I tried to build enkiTS on Windows10 with MinGW64 (GCC13) example demos raised this error:
```gcc
C:\Users\User\Desktop\enkiTS\example\ParallelSum.cpp:60:9: error: 'memset' was not declared in this scope
   60 |         memset( m_pPartialSums, 0, sizeof(Count)*m_NumPartialSums );
      |         ^~~~~~
```
This PR fixes them.