### PR TITLE
Change `Windows.h` to `windows.h` to help with cross-compilation.

### DIFF
--- a/example/ExternalTaskThread_c.c
+++ b/example/ExternalTaskThread_c.c
@@ -27,7 +27,7 @@
 
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
     
 typedef HANDLE threadid_t;
 #define THREADFUNC_DECL DWORD WINAPI

--- a/src/TaskScheduler.cpp
+++ b/src/TaskScheduler.cpp
@@ -55,7 +55,7 @@ namespace
 #ifndef NOMINMAX
     #define NOMINMAX
 #endif
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 uint32_t enki::GetNumHardwareThreads()
@@ -1320,7 +1320,7 @@ void TaskScheduler::Initialize()
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace enki
 {


### PR DESCRIPTION
Hello!

Currently this library can't be cross-compiled to Windows from e.g. Linux, because the header names are case-sensitive there, and you're using `#include <Windows.h>`, while mingw has this file named `windows.h` (lowercase).

I've changed it to lowercase everywhere.
