### PR TITLE
Update CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project( enkiTS )
 


### PR DESCRIPTION
For issue #124

Current versions of CMake give deprecation warnings about version usage previous to 3.5.