### PR TITLE
Fix: Mark deprecated functions [[deprecated]]

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ struct RunPinnedTaskLoopTask : enki::IPinnedTask
 {
     void Execute() override
     {
-        while( g_TS.GetIsRunning() )
+        while( !g_TS.GetIsShutdownRequested() )
         {
             g_TS.WaitForNewPinnedTasks(); // this thread will 'sleep' until there are new pinned tasks
             g_TS.RunPinnedTasks();

--- a/example/WaitForNewPinnedTasks.cpp
+++ b/example/WaitForNewPinnedTasks.cpp
@@ -57,7 +57,7 @@ struct RunPinnedTaskLoopTask : IPinnedTask
 {
     void Execute() override
     {
-        while( g_TS.GetIsRunning() )
+        while( !g_TS.GetIsShutdownRequested() )
         {
             g_TS.WaitForNewPinnedTasks(); // this thread will 'sleep' until there are new pinned tasks
             g_TS.RunPinnedTasks();
@@ -133,7 +133,7 @@ int main(int argc, const char * argv[])
             g_TS.AddPinnedTask( &pretendDoNetworkIO[ ioThreadID - (uint32_t)IOThreadId::NETWORK_IO_0 ] );
         }
 
-        g_TS.WaitforTaskSet( &parallelTaskSet );
+        g_TS.WaitforTask( &parallelTaskSet );
 
         // in this example  we need to wait for IO tasks to complete before running next loop
         g_TS.WaitforTask( &pretendDoFileIO  );

--- a/example/WaitForNewPinnedTasks_c.c
+++ b/example/WaitForNewPinnedTasks_c.c
@@ -38,7 +38,7 @@ void PinnedTaskRunPinnedTaskLoop( void* pArgs_ )
     assert( threadNum == threadNumDesired );
     printf("PinnedTaskRunPinnedTaskLoop running on thread %d (should be thread %d)\n", threadNum, threadNumDesired );
 
-    while( enkiGetIsRunning( pETS ) )
+    while( !enkiGetIsShutdownRequested( pETS ) )
     {
         enkiWaitForNewPinnedTasks( pETS );
         enkiRunPinnedTasks( pETS );
@@ -83,7 +83,7 @@ int main(int argc, const char * argv[])
     enkiDeletePinnedTask( pETS, pPinnedTaskPretendIO );
 
 
-    // Shutdown enkiTS, which will cause pPinnedTaskRunPinnedTaskLoop to exit as enkiGetIsRunning will return false
+    // Shutdown enkiTS, which will cause pPinnedTaskRunPinnedTaskLoop to exit as enkiGetIsShutdownRequested will return true
     enkiWaitforAllAndShutdown( pETS );
 
     // delete the tasks before the scheduler

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -58,6 +58,12 @@
 #define ENKI_ASSERT(x) assert(x)
 #endif
 
+#if (!defined(_MSVC_LANG) && __cplusplus >= 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define ENKI_DEPRECATED [[deprecated]]
+#else
+#define ENKI_DEPRECATED
+#endif
+
 namespace enki
 {
     struct TaskSetPartition
@@ -418,15 +424,15 @@ namespace enki
         // DEPRECATED: use GetIsShutdownRequested() instead of GetIsRunning() in external code
         // while( GetIsRunning() ) {} can be used in tasks which loop, to check if enkiTS has been shutdown.
         // If GetIsRunning() returns false should then exit. Not required for finite tasks.
-        inline     bool            GetIsRunning() const { return m_bRunning.load( std::memory_order_acquire ); }
+        ENKI_DEPRECATED inline bool GetIsRunning() const { return m_bRunning.load( std::memory_order_acquire ); }
 
         // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask.
-        inline void                WaitforTaskSet( const ICompletable* pCompletable_ ) { WaitforTask( pCompletable_ ); }
+        ENKI_DEPRECATED inline void WaitforTaskSet( const ICompletable* pCompletable_ ) { WaitforTask( pCompletable_ ); }
 
         // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead.
         // Returns the ProfilerCallbacks structure so that it can be modified to
         // set the callbacks. Should be set prior to initialization.
-        inline ProfilerCallbacks* GetProfilerCallbacks() { return &m_Config.profilerCallbacks; }
+        ENKI_DEPRECATED inline ProfilerCallbacks* GetProfilerCallbacks() { return &m_Config.profilerCallbacks; }
         // -------------  End DEPRECATED Functions  -------------
 
     private:

--- a/src/TaskScheduler_c.cpp
+++ b/src/TaskScheduler_c.cpp
@@ -158,6 +158,16 @@ int enkiGetIsRunning( enkiTaskScheduler* pETS_ )
     return (int)pETS_->GetIsRunning();
 }
 
+int enkiGetIsShutdownRequested(enkiTaskScheduler* pETS_)
+{
+    return (int)pETS_->GetIsShutdownRequested();
+}
+
+int enkiGetIsWaitforAllCalled( enkiTaskScheduler* pETS_ )
+{
+    return (int)pETS_->GetIsWaitforAllCalled();
+}
+
 void enkiInitTaskScheduler(  enkiTaskScheduler* pETS_ )
 {
     pETS_->Initialize();

--- a/src/TaskScheduler_c.h
+++ b/src/TaskScheduler_c.h
@@ -145,6 +145,18 @@ ENKITS_API struct enkiTaskSchedulerConfig enkiGetTaskSchedulerConfig( enkiTaskSc
 // If enkiGetIsRunning() returns false should then exit. Not required for finite tasks
 ENKITS_API int                 enkiGetIsRunning( enkiTaskScheduler* pETS_ );
 
+// while( !enkiGetIsShutdownRequested() ) {} can be used in tasks which loop, to check if enkiTS has been requested to shutdown.
+// If enkiGetIsShutdownRequested() returns true should then exit. Not required for finite tasks
+// Safe to use with enkiWaitforAllAndShutdown() where this will be set
+// Not safe to use with enkiWaitforAll(), use enkiGetIsWaitforAllCalled() instead.
+ENKITS_API int                 enkiGetIsShutdownRequested( enkiTaskScheduler* pETS_ );
+
+// while( !enkiGetIsWaitforAllCalled() ) {} can be used in tasks which loop, to check if enkiWaitforAll() has been called.
+// If enkiGetIsWaitforAllCalled() returns false should then exit. Not required for finite tasks
+// This is intended to be used with code which calls enkiWaitforAll().
+// This is also set when the task manager is shutting down, so no need to have an additional check for enkiGetIsShutdownRequested()
+ENKITS_API int                 enkiGetIsWaitforAllCalled( enkiTaskScheduler* pETS_ );
+
 // Initialize task scheduler - will create GetNumHardwareThreads()-1 threads, which is
 // sufficient to fill the system when including the main thread.
 // Initialize can be called multiple times - it will wait for completion


### PR DESCRIPTION
This additionally replaces usages of `GetIsRunning` with `GetIsShutdownRequested`, and exposes the latter in the C API.

Partially fixes #128. Note that this does add a fair share of warnings to the compile output, since the deprecated functions are used internally. I also added `enkiGetIsWaitforAllCalled` for the C API since it was referenced in the documentation as a replacement for `enkiWaitforAll`, which already existed, so that only seemed logical.