### PR TITLE
TaskScheduler.h: add a missing #include <utility>

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -20,9 +20,10 @@
 
 #include <atomic>
 #include <thread>
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <utility>
 
 // ENKITS_TASK_PRIORITIES_NUM can be set from 1 to 5.
 // 1 corresponds to effectively no priorities.


### PR DESCRIPTION
Fixes
```
include/enkiTS/TaskScheduler.h:114:103: error: ‘std::initializer_list’ has not been declared
```
when compiling with aarch64-linux-gnu-g++-14.