### PR TITLE
[bugfix] Install DLL according to CMake configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,22 +22,18 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
-            - name: Install static artifacts
-              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
-            - name: Install shared artifacts
-              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-linux-gcc:
         name: Linux, gcc
@@ -52,22 +48,18 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
-            - name: Install static artifacts
-              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
-            - name: Install shared artifacts
-              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-ubuntu-zig:
         name: Linux, zig
@@ -99,22 +91,18 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
-            - name: Install static artifacts
-              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
-            - name: Install shared artifacts
-              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-windows-win32-vs2022:
         name: Win32 (Windows, VS2022)
@@ -131,22 +119,18 @@ jobs:
                 arch: x64
 
             - name: Configure static library
-              run: cmake -S . -B build-static -G "Visual Studio 17 2022" -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-static -G "Visual Studio 17 2022" -D ENKITS_SANITIZE=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: .\build-static\Debug\TestAll.exe
-            - name: Install static artifacts
-              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -G "Visual Studio 17 2022" -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
+              run: cmake -S . -B build-shared -G "Visual Studio 17 2022" -D ENKITS_BUILD_SHARED=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: .\build-shared\Debug\TestAll.exe
-            - name: Install shared artifacts
-              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-windows-win32-zig:
         name: Win32 (Windows, zig)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,22 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
+            - name: Install static artifacts
+              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
+            - name: Install shared artifacts
+              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-linux-gcc:
         name: Linux, gcc
@@ -48,18 +52,22 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
+            - name: Install static artifacts
+              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
+            - name: Install shared artifacts
+              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-ubuntu-zig:
         name: Linux, zig
@@ -91,18 +99,22 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure static library
-              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON
+              run: cmake -S . -B build-static -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: ./build-static/TestAll
+            - name: Install static artifacts
+              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON
+              run: cmake -S . -B build-shared -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: ./build-shared/TestAll
+            - name: Install shared artifacts
+              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-windows-win32-vs2022:
         name: Win32 (Windows, VS2022)
@@ -119,18 +131,22 @@ jobs:
                 arch: x64
 
             - name: Configure static library
-              run: cmake -S . -B build-static -G "Visual Studio 17 2022" -D ENKITS_SANITIZE=ON
+              run: cmake -S . -B build-static -G "Visual Studio 17 2022" -D ENKITS_SANITIZE=ON -DENKITS_INSTALL=ON
             - name: Build static library
               run: cmake --build build-static --parallel
             - name: Test static library
               run: .\build-static\Debug\TestAll.exe
+            - name: Install static artifacts
+              run: cmake --install build-static --prefix ${{ github.workspace }}/install-static
 
             - name: Configure shared library
-              run: cmake -S . -B build-shared -G "Visual Studio 17 2022" -D ENKITS_BUILD_SHARED=ON
+              run: cmake -S . -B build-shared -G "Visual Studio 17 2022" -D ENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
             - name: Build shared library
               run: cmake --build build-shared --parallel
             - name: Test shared library
               run: .\build-shared\Debug\TestAll.exe
+            - name: Install shared artifacts
+              run: cmake --install build-shared --prefix ${{ github.workspace }}/install-shared
 
     build-windows-win32-zig:
         name: Win32 (Windows, zig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project( enkiTS 
+project( enkiTS
          VERSION "1.11"
          DESCRIPTION "A C and C++ task scheduler for creating parallel programs"
          HOMEPAGE_URL "https://github.com/dougbinks/enkiTS"
@@ -85,7 +85,9 @@ if( ENKITS_INSTALL )
     install(
         TARGETS enkiTS
         EXPORT enkiTSConfig
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/enkiTS)
     install(
         EXPORT enkiTSConfig


### PR DESCRIPTION
Greetings! 👋 

As we are reviewing the Conan recipe for enkiTS version 1.12 in https://github.com/conan-io/conan-center-index/pull/30558, we noted when installing the project using CMake, for Windows shared libraries, the produced `enkiTS.dll` is not copied to the final folder configured via `CMAKE_INSTALL_PREFIX`:

```
-- Install configuration: "Release"
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/enkiTS.lib
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/LockLessMultiReadPipe.h
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/TaskScheduler.h
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/TaskScheduler_c.h
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/cmake/enkiTS/enkiTSConfig.cmake
-- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/cmake/enkiTS/enkiTSConfig-release.cmake
```

You can check my full build log without Conan, only CMake + Windows: [enkits-1.12-windows-amd64-msvc194-release-shared.log](https://github.com/user-attachments/files/30186857/enkits-1.12-windows-amd64-msvc194-release-shared.log)

When building on Windows, with `ENKITS_BUILD_SHARED=ON`, the install step correctly copies `enkiTS.lib`, because the `ARCHIVE` destination is defined in `install()`, but there's no `RUNTIME DESTINATION` clause, so the actual `enkiTS.dll` is silently skipped.

This same install rule would also silently skip the .so on Linux/macOS shared builds, since there's no `LIBRARY DESTINATION` either.

References:
- https://cmake.org/cmake/help/latest/command/install.html#targets

After applying the proposed patch in this PR, I can build and install that missing DLL file with success:

```
-- Install configuration: "Release"
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/enkiTS.lib
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/bin/enkiTS.dll
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/LockLessMultiReadPipe.h
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/TaskScheduler.h
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/include/enkiTS/TaskScheduler_c.h
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/cmake/enkiTS/enkiTSConfig.cmake
  -- Installing: C:/Users/uilia/AppData/Local/Temp/tmp.Q5CD7rXqLq/install/lib/cmake/enkiTS/enkiTSConfig-release.cmake
```

You can check my full build log with this patch applied: [enkits-1.12-windows-amd64-msvc194-release-shared-patched.log](https://github.com/user-attachments/files/30187004/enkits-1.12-windows-amd64-msvc194-release-shared-patched.log)

#### Steps to Reproduce

```
cmake -S . -B build -DCMAKE_INSTALL_PREFIX=%TEMP%/enkits-install -DCMAKE_VERBOSE_MAKEFILE=ON -DENKITS_BUILD_EXAMPLES=OFF -DENKITS_BUILD_SHARED=ON -DENKITS_INSTALL=ON
cmake --build build --config Release
cmake --build build --config Release --target install
```

#### Environment

* EnkiTS: 1.12 (https://github.com/dougbinks/enkiTS/archive/refs/tags/v1.12.tar.gz)
* OS: Windows 10
* Arch: Intel x86_64
* Compiler: MSVC 19.44.35228.0
* Build Type: Release
* CMake: 4.3.2
* CMake Options: ENKITS_BUILD_SHARED=ON ENKITS_INSTALL=ON

Feel free to ask for further information! Regards! 